### PR TITLE
feat: Implement DJLinkGen CLI and Web versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.so
+*.DS_Store
+venv/
+env/
+.env*
+!/.env.example # Não ignorar os arquivos .env.example
+
+# Node (se usado para desenvolvimento web ou ferramentas)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp/
+.pnp.js
+
+# Build artifacts
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# DJLinkGen: Gerador de Links para Consulta no Diário de Justiça
+
+Bem-vindo ao DJLinkGen! Este projeto fornece ferramentas para simplificar a geração de links de consulta para publicações no Diário de Justiça Eletrônico.
+
+## Visão Geral
+
+O DJLinkGen oferece duas maneiras de gerar seus links:
+
+1.  **`DJLinkGen-CLI`**: Uma ferramenta de linha de comando em Python para usuários que preferem o terminal.
+2.  **`DJLinkGen-Web`**: Uma interface web amigável e de página única para uso direto no navegador.
+
+Ambas as ferramentas permitem que você use seu número de OAB e UF, com opções flexíveis de filtro por data.
+
+## Componentes do Projeto
+
+* **[DJLinkGen-CLI](./djlinkgen_cli/README.md)**: Instruções detalhadas e código para a versão de linha de comando.
+* **[DJLinkGen-Web](./djlinkgen_web/README.md)**: Instruções detalhadas e código para a interface web.
+
+## Como Contribuir
+
+Contribuições são muito bem-vindas! Se você tem ideias para melhorias, novas funcionalidades ou encontrou algum bug, sinta-se à vontade para:
+
+* Abrir uma [Issue](https://github.com/USER/REPO/issues).
+* Enviar um [Pull Request](https://github.com/USER/REPO/pulls).
+
+## Licença
+
+Este projeto é distribuído sob la licença MIT License (Placeholder).

--- a/djlinkgen_cli/README.md
+++ b/djlinkgen_cli/README.md
@@ -1,0 +1,126 @@
+# DJLinkGen-CLI: Gerador de Links para Diário de Justiça (Linha de Comando)
+
+Esta ferramenta CLI permite gerar rapidamente links para consulta de publicações no Diário de Justiça Eletrônico.
+
+## Funcionalidades
+
+* Gera links com base no seu número de OAB e UF.
+* Opções de filtro por data: sem filtro, últimos 5 dias, ou intervalo personalizado.
+* Salva suas informações de OAB em um arquivo `.env` para uso futuro.
+* Tenta copiar o link gerado para a área de transferência.
+
+## Pré-requisitos
+
+* Python 3.7 ou superior.
+* `pip` (gerenciador de pacotes Python).
+
+## Instalação
+
+1.  **Clone o repositório (se ainda não o fez):**
+    ```bash
+    git clone https://github.com/USER/REPO
+    cd DJLinkGen/djlinkgen_cli
+    ```
+
+2.  **Crie e ative um ambiente virtual (recomendado):**
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate  # Linux/macOS
+    # venv\Scripts\activate   # Windows
+    ```
+
+3.  **Instale as dependências:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## Configuração
+
+Antes de usar a ferramenta pela primeira vez, você pode configurar suas informações da OAB.
+
+1.  **Crie um arquivo `.env`:**
+    Copie o arquivo `.env.example` para `.env`:
+    ```bash
+    cp .env.example .env  # Linux/macOS
+    # copy .env.example .env # Windows
+    ```
+
+2.  **Edite o arquivo `.env`:**
+    Abra o arquivo `.env` em um editor de texto e preencha com seu número da OAB e UF:
+    ```ini
+    OAB_NUMBER="SEUNUMEROAQUI"
+    OAB_UF="SUAUFAQUI"
+    ```
+    Se você não criar este arquivo, a ferramenta solicitará essas informações na primeira execução e oferecerá a opção de salvá-las.
+
+## Uso
+
+1.  Certifique-se de que seu ambiente virtual está ativado (se você criou um).
+2.  Navegue até o diretório `djlinkgen_cli`.
+3.  Execute o script:
+    ```bash
+    python djlinkgen.py
+    ```
+4.  Siga as instruções no terminal para selecionar o filtro de data e gerar o link.
+
+## Criando um Alias para Acesso Rápido (Opcional)
+
+Para executar a ferramenta de qualquer lugar no seu terminal usando um comando simples (ex: `djlink`), você pode criar um alias.
+
+### Linux e macOS (bash/zsh)
+
+1.  Abra seu arquivo de configuração do shell (`~/.bashrc` para bash, `~/.zshrc` para zsh):
+    ```bash
+    nano ~/.bashrc  # Ou use seu editor preferido
+    # nano ~/.zshrc
+    ```
+2.  Adicione a seguinte linha ao final do arquivo, substituindo `/caminho/completo/para/DJLinkGen/djlinkgen_cli` pelo caminho absoluto onde o script `djlinkgen.py` está localizado no seu sistema:
+    ```bash
+    alias djlink='python /caminho/completo/para/DJLinkGen/djlinkgen_cli/djlinkgen.py'
+    ```
+    *Dica: Você pode obter o caminho completo navegando até o diretório `djlinkgen_cli` e executando `pwd`.*
+3.  Salve o arquivo e recarregue a configuração do shell:
+    ```bash
+    source ~/.bashrc  # Ou source ~/.zshrc
+    ```
+4.  Agora você pode usar o comando `djlink` de qualquer diretório.
+
+### Windows
+
+#### PowerShell
+
+1.  Verifique se você tem um perfil do PowerShell. Digite no PowerShell:
+    ```powershell
+    Test-Path $PROFILE
+    ```
+2.  Se retornar `False`, crie um:
+    ```powershell
+    New-Item -Type File -Path $PROFILE -Force
+    ```
+3.  Abra seu perfil do PowerShell para edição (ex: com o Bloco de Notas):
+    ```powershell
+    notepad $PROFILE
+    ```
+4.  Adicione a seguinte linha, substituindo `C:\caminho\completo\para\DJLinkGen\djlinkgen_cli\djlinkgen.py` pelo caminho absoluto para o script:
+    ```powershell
+    Set-Alias -Name djlink -Value "python C:\caminho\completo\para\DJLinkGen\djlinkgen_cli\djlinkgen.py"
+    ```
+    *Se o Python não estiver no seu PATH, você pode precisar especificar o caminho completo para `python.exe` também.*
+5.  Salve o arquivo e feche o editor. Para aplicar as alterações, feche e reabra o PowerShell ou execute:
+    ```powershell
+    . $PROFILE
+    ```
+6.  Agora você pode usar o comando `djlink`.
+
+#### Prompt de Comando (CMD) via `doskey` (Menos permanente)
+
+1.  Você pode criar um alias temporário usando `doskey`:
+    ```cmd
+    doskey djlink=python C:\caminho\completo\para\DJLinkGen\djlinkgen_cli\djlinkgen.py $*
+    ```
+    Substitua o caminho conforme necessário. Este alias durará apenas para a sessão atual do CMD.
+2.  Para torná-lo mais permanente, você pode adicionar este comando `doskey` a um arquivo `.bat` que é executado quando o CMD inicia (por exemplo, através de uma chave de AutoRun no Registro do Windows, o que é mais avançado). Uma maneira mais simples é criar um arquivo `.bat` (ex: `djlink_alias.bat`) com o comando `doskey` e colocá-lo em um diretório no seu PATH, e então executar esse `.bat` uma vez por sessão.
+
+## Contribuições
+
+Contribuições são bem-vindas! Sinta-se à vontade para abrir issues ou pull requests.

--- a/djlinkgen_cli/djlinkgen.py
+++ b/djlinkgen_cli/djlinkgen.py
@@ -1,0 +1,134 @@
+import os
+import datetime
+from dotenv import load_dotenv, find_dotenv, set_key
+import pyperclip
+import urllib.parse
+import webbrowser
+
+def main():
+    # 2. Load Environment Variables
+    load_dotenv()
+    oab_number = os.getenv("OAB_NUMBER")
+    oab_uf = os.getenv("OAB_UF")
+
+    # 3. Handle OAB Input
+    if not oab_number or not oab_uf:
+        print("Informações da OAB não encontradas nas variáveis de ambiente.")
+        oab_number_input = input("Digite o número da sua OAB: ").strip()
+        oab_uf_input = ""
+        while True:
+            oab_uf_input = input("Digite a UF da sua OAB (ex: RJ): ").strip().upper()
+            if len(oab_uf_input) == 2 and oab_uf_input.isalpha():
+                break
+            print("UF inválida. Por favor, digite 2 letras (ex: RJ).")
+
+        save_env = input("Deseja salvar estas informações em um arquivo .env para uso futuro? (s/n): ").strip().lower()
+        if save_env == 's':
+            dotenv_path = find_dotenv(usecwd=True, raise_error_if_not_found=False)
+            if not dotenv_path:
+                # Create .env file if it doesn't exist
+                with open('.env', 'w') as f:
+                    pass
+                dotenv_path = find_dotenv(usecwd=True)
+
+            if dotenv_path: # Should always exist now
+                set_key(dotenv_path, "OAB_NUMBER", oab_number_input)
+                set_key(dotenv_path, "OAB_UF", oab_uf_input)
+                print(f"Informações salvas em {dotenv_path}")
+                oab_number = oab_number_input # Use the input values for the current session
+                oab_uf = oab_uf_input
+            else:
+                print("Não foi possível encontrar ou criar o arquivo .env para salvar as informações.")
+                # Use the input values for the current session even if not saved
+                oab_number = oab_number_input
+                oab_uf = oab_uf_input
+    else:
+        print(f"Usando OAB: {oab_number}/{oab_uf} (configurado no .env)")
+
+
+    # 4. Date Filter Selection
+    data_inicio_str = None
+    data_fim_str = None
+
+    while True:
+        print("\nEscolha o filtro de data para a consulta:")
+        print("[1] Em Aberto (sem filtro de data)")
+        print("[2] Últimos 5 dias")
+        print("[3] Definir intervalo personalizado")
+        date_choice = input("Sua opção: ").strip()
+
+        if date_choice in ['1', '2', '3']:
+            break
+        print("Opção inválida. Por favor, escolha 1, 2 ou 3.")
+
+    # 5. Date Logic
+    if date_choice == '2': # Últimos 5 dias
+        data_fim = datetime.date.today()
+        data_inicio = data_fim - datetime.timedelta(days=4)
+        data_inicio_str = data_inicio.strftime("%Y-%m-%d")
+        data_fim_str = data_fim.strftime("%Y-%m-%d")
+        print(f"Filtrando por datas: Início: {data_inicio_str}, Fim: {data_fim_str}")
+    elif date_choice == '3': # Intervalo Personalizado
+        while True:
+            try:
+                start_date_input = input("Data de início (AAAA-MM-DD): ").strip()
+                data_inicio = datetime.datetime.strptime(start_date_input, "%Y-%m-%d").date()
+                break
+            except ValueError:
+                print("Formato de data inválido. Use AAAA-MM-DD.")
+        
+        while True:
+            try:
+                end_date_input = input("Data de fim (AAAA-MM-DD): ").strip()
+                data_fim = datetime.datetime.strptime(end_date_input, "%Y-%m-%d").date()
+                if data_fim < data_inicio:
+                    print("A data de fim não pode ser anterior à data de início. Tente novamente.")
+                    continue
+                break
+            except ValueError:
+                print("Formato de data inválido. Use AAAA-MM-DD.")
+        
+        data_inicio_str = data_inicio.strftime("%Y-%m-%d")
+        data_fim_str = data_fim.strftime("%Y-%m-%d")
+        print(f"Filtrando por datas: Início: {data_inicio_str}, Fim: {data_fim_str}")
+
+    # 6. URL Generation
+    base_url = "https://comunica.pje.jus.br/consulta"
+    params = {
+        "meio": "D",
+        "numeroOab": oab_number,
+        "ufOab": oab_uf
+    }
+    if data_inicio_str and data_fim_str:
+        params["dataDisponibilizacaoInicio"] = data_inicio_str
+        params["dataDisponibilizacaoFim"] = data_fim_str
+
+    # Filter out None values from params, just in case, though oab_number and oab_uf should be set
+    # However, if the user chose not to save and also didn't provide valid OAB details initially (edge case not fully handled yet)
+    # this could be an issue. For now, assuming oab_number and oab_uf are always populated if we reach this stage.
+    query_string = urllib.parse.urlencode(params)
+    generated_url = f"{base_url}?{query_string}"
+
+    # 7. Display Link
+    print(f"\nLink gerado: {generated_url}")
+
+    # 8. Copy to Clipboard
+    try:
+        pyperclip.copy(generated_url)
+        print("Link copiado para a área de transferência!")
+    except pyperclip.PyperclipUnavailableException:
+        print("Pyperclip não está disponível. Instale xclip ou xsel para copiar para a área de transferência no Linux.")
+        print("Por favor, copie o link manualmente.")
+    except Exception as e: # Catching other potential pyperclip errors
+        print(f"Não foi possível copiar para a área de transferência: {e}")
+        print("Por favor, copie o link manualmente.")
+
+    # 9. Open in browser
+    try:
+        print("Abrindo link no navegador...")
+        webbrowser.open(generated_url)
+    except Exception as e:
+        print(f"Não foi possível abrir o link no navegador: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/djlinkgen_cli/requirements.txt
+++ b/djlinkgen_cli/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv
+pyperclip

--- a/djlinkgen_web/README.md
+++ b/djlinkgen_web/README.md
@@ -1,0 +1,39 @@
+# DJLinkGen-Web: Gerador de Links para Diário de Justiça (Interface Web)
+
+Esta é uma interface web de página única para gerar links de consulta de publicações no Diário de Justiça Eletrônico.
+
+## Funcionalidades
+
+* Interface amigável com tema escuro e design minimalista.
+* Entrada de número da OAB e UF.
+* Opções de filtro por data: sem filtro, últimos 5 dias, ou intervalo personalizado.
+* Geração instantânea do link de consulta.
+* Botão para copiar o link gerado para a área de transferência.
+* Opção "Lembrar meus dados" usando o armazenamento local do navegador.
+
+## Como Usar
+
+1.  **Clone o repositório (se ainda não o fez):**
+    ```bash
+    git clone https://github.com/USER/REPO
+    cd DJLinkGen/djlinkgen_web
+    ```
+2.  **Abra o arquivo `index.html`:**
+    Simplesmente abra o arquivo `index.html` em seu navegador de internet preferido (Chrome, Firefox, Edge, etc.). Não é necessário um servidor web para a funcionalidade básica, mas pode ser útil para desenvolvimento.
+
+3.  **Preencha os campos:**
+    * Informe seu número da OAB e UF.
+    * Marque "Lembrar meus dados" se desejar que estas informações sejam salvas no seu navegador para a próxima visita.
+    * Escolha a opção de filtro de data desejada.
+    * Clique em "Gerar Link".
+
+4.  **Copie o link:**
+    O link gerado aparecerá na tela. Você pode clicá-lo para abrir em uma nova aba ou usar o botão "Copiar Link".
+
+## Arquivo `.env.example`
+
+O arquivo `.env.example` é fornecido como referência para o desenvolvedor. Em um contexto de desenvolvimento local com ferramentas que suportam variáveis de ambiente (como alguns servidores de desenvolvimento Node.js), ele poderia ser usado para pré-preencher valores. Para o uso normal desta página estática, ele não é diretamente utilizado pelo `index.html` no navegador do usuário final.
+
+## Contribuições
+
+Contribuições são bem-vindas!

--- a/djlinkgen_web/index.html
+++ b/djlinkgen_web/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DJLinkGen-Web: Gerador de Links para Diário de Justiça</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Gerador de Links para Diário de Justiça</h1>
+        </header>
+
+        <main>
+            <form id="djLinkForm">
+                <div class="form-group">
+                    <label for="oabNumber">Número da OAB:</label>
+                    <input type="text" id="oabNumber" name="oabNumber" required>
+                </div>
+
+                <div class="form-group">
+                    <label for="oabUF">UF da OAB:</label>
+                    <input type="text" id="oabUF" name="oabUF" required maxlength="2" pattern="[A-Za-z]{2}">
+                </div>
+
+                <div class="form-group">
+                    <input type="checkbox" id="rememberMe" name="rememberMe">
+                    <label for="rememberMe">Lembrar meus dados</label>
+                </div>
+
+                <fieldset class="form-group">
+                    <legend>Escolha o filtro de data:</legend>
+                    <div>
+                        <input type="radio" id="dateFilterOpen" name="dateFilter" value="open" checked>
+                        <label for="dateFilterOpen">Em Aberto (sem filtro de data)</label>
+                    </div>
+                    <div>
+                        <input type="radio" id="dateFilterLast5" name="dateFilter" value="last5">
+                        <label for="dateFilterLast5">Últimos 5 dias</label>
+                    </div>
+                    <div>
+                        <input type="radio" id="dateFilterCustom" name="dateFilter" value="custom">
+                        <label for="dateFilterCustom">Definir intervalo personalizado</label>
+                    </div>
+                </fieldset>
+
+                <div id="customDateFields" class="form-group" style="display: none;">
+                    <div>
+                        <label for="startDate">Data de início (AAAA-MM-DD):</label>
+                        <input type="date" id="startDate" name="startDate">
+                    </div>
+                    <div>
+                        <label for="endDate">Data de fim (AAAA-MM-DD):</label>
+                        <input type="date" id="endDate" name="endDate">
+                    </div>
+                </div>
+
+                <button type="submit" id="generateLinkButton">Gerar Link</button>
+            </form>
+
+            <div id="resultArea" style="display: none;">
+                <h2>Link Gerado:</h2>
+                <a href="#" id="generatedLink" target="_blank"></a>
+                <button id="copyLinkButton">Copiar Link</button>
+            </div>
+
+            <div id="messageArea">
+                <!-- Messages will be displayed here -->
+            </div>
+        </main>
+
+        <footer>
+            <p>DJLinkGen-Web</p>
+        </footer>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/djlinkgen_web/script.js
+++ b/djlinkgen_web/script.js
@@ -1,0 +1,172 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const djLinkForm = document.getElementById('djLinkForm');
+    const oabNumberInput = document.getElementById('oabNumber');
+    const oabUFInput = document.getElementById('oabUF');
+    const rememberMeCheckbox = document.getElementById('rememberMe');
+    const dateFilterRadios = document.querySelectorAll('input[name="dateFilter"]');
+    const customDateFieldsDiv = document.getElementById('customDateFields');
+    const startDateInput = document.getElementById('startDate');
+    const endDateInput = document.getElementById('endDate');
+    const resultAreaDiv = document.getElementById('resultArea');
+    const generatedLinkAnchor = document.getElementById('generatedLink');
+    const copyLinkButton = document.getElementById('copyLinkButton');
+    const messageAreaDiv = document.getElementById('messageArea');
+
+    // Load saved OAB data
+    if (localStorage.getItem('rememberMe') === 'true') {
+        oabNumberInput.value = localStorage.getItem('oabNumber') || '';
+        oabUFInput.value = localStorage.getItem('oabUF') || '';
+        rememberMeCheckbox.checked = true;
+    }
+
+    // Toggle custom date fields visibility
+    dateFilterRadios.forEach(radio => {
+        radio.addEventListener('change', (event) => {
+            if (event.target.value === 'custom') {
+                customDateFieldsDiv.style.display = 'block';
+            } else {
+                customDateFieldsDiv.style.display = 'none';
+            }
+        });
+    });
+
+    // Form submission handler
+    djLinkForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        clearMessages();
+        resultAreaDiv.style.display = 'none';
+
+        const oabNumber = oabNumberInput.value.trim();
+        const oabUF = oabUFInput.value.trim().toUpperCase();
+        const dateFilter = document.querySelector('input[name="dateFilter"]:checked').value;
+
+        // Validate OAB UF
+        if (!/^[A-Z]{2}$/.test(oabUF)) {
+            showMessage('UF da OAB inválida. Use 2 letras (ex: SP, RJ).', 'error');
+            return;
+        }
+
+        // Save OAB data if "Remember me" is checked
+        if (rememberMeCheckbox.checked) {
+            localStorage.setItem('oabNumber', oabNumber);
+            localStorage.setItem('oabUF', oabUF);
+            localStorage.setItem('rememberMe', 'true');
+        } else {
+            localStorage.removeItem('oabNumber');
+            localStorage.removeItem('oabUF');
+            localStorage.setItem('rememberMe', 'false');
+        }
+
+        let dataInicioStr = null;
+        let dataFimStr = null;
+
+        if (dateFilter === 'last5') {
+            const today = new Date();
+            const endDate = new Date(today);
+            const startDate = new Date(today);
+            startDate.setDate(today.getDate() - 4);
+
+            dataInicioStr = formatDate(startDate);
+            dataFimStr = formatDate(endDate);
+
+        } else if (dateFilter === 'custom') {
+            const startDateValue = startDateInput.value;
+            const endDateValue = endDateInput.value;
+
+            if (!startDateValue || !endDateValue) {
+                showMessage('Por favor, preencha as datas de início e fim.', 'error');
+                return;
+            }
+            // Basic validation for date format is handled by type="date",
+            // but more specific validation (e.g. YYYY-MM-DD) might be needed if not using native date picker
+            const startDateObj = new Date(startDateValue + "T00:00:00"); // Add time to avoid timezone issues
+            const endDateObj = new Date(endDateValue + "T00:00:00");
+
+            if (startDateObj > endDateObj) {
+                showMessage('A data de início não pode ser posterior à data de fim.', 'error');
+                return;
+            }
+            dataInicioStr = startDateValue;
+            dataFimStr = endDateValue;
+        }
+
+        // Generate URL
+        const baseURL = 'https://comunica.pje.jus.br/consulta';
+        const params = new URLSearchParams();
+        params.append('meio', 'D');
+        params.append('numeroOab', oabNumber);
+        params.append('ufOab', oabUF);
+
+        if (dataInicioStr) {
+            params.append('dataDisponibilizacaoInicio', dataInicioStr);
+        }
+        if (dataFimStr) {
+            params.append('dataDisponibilizacaoFim', dataFimStr);
+        }
+
+        const generatedURL = `${baseURL}?${params.toString()}`;
+
+        generatedLinkAnchor.href = generatedURL;
+        generatedLinkAnchor.textContent = generatedURL;
+        resultAreaDiv.style.display = 'block';
+        showMessage('Link gerado com sucesso!', 'success');
+    });
+
+    // Copy link to clipboard
+    copyLinkButton.addEventListener('click', () => {
+        if (navigator.clipboard && generatedLinkAnchor.href && generatedLinkAnchor.href !== '#') {
+            navigator.clipboard.writeText(generatedLinkAnchor.href)
+                .then(() => {
+                    showMessage('Link copiado para a área de transferência!', 'success');
+                })
+                .catch(err => {
+                    showMessage('Falha ao copiar o link. Tente manualmente.', 'error');
+                    console.error('Error copying to clipboard:', err);
+                });
+        } else {
+            // Fallback for older browsers or if link is not generated
+            try {
+                const textArea = document.createElement('textarea');
+                textArea.value = generatedLinkAnchor.href;
+                textArea.style.position = 'fixed'; // Prevent scrolling to bottom
+                document.body.appendChild(textArea);
+                textArea.focus();
+                textArea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textArea);
+                showMessage('Link copiado para a área de transferência! (fallback)', 'success');
+            } catch (err) {
+                showMessage('Não foi possível copiar o link. Por favor, copie manualmente.', 'error');
+            }
+        }
+    });
+
+    // Helper function to format date as YYYY-MM-DD
+    function formatDate(date) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    }
+
+    // Helper function to show messages
+    function showMessage(message, type) {
+        messageAreaDiv.textContent = message;
+        messageAreaDiv.className = `message-${type}`; // e.g., message-success or message-error
+        
+        // Clear message after some time
+        setTimeout(() => {
+            clearMessages();
+        }, 5000); // Message visible for 5 seconds
+    }
+    
+    function clearMessages() {
+        messageAreaDiv.textContent = '';
+        messageAreaDiv.className = '';
+    }
+
+    // Initial check for custom date fields based on loaded radio state (e.g. if 'custom' is checked by default)
+    if (document.querySelector('input[name="dateFilter"]:checked').value === 'custom') {
+        customDateFieldsDiv.style.display = 'block';
+    }
+});

--- a/djlinkgen_web/style.css
+++ b/djlinkgen_web/style.css
@@ -1,0 +1,190 @@
+body {
+    background-color: #121212;
+    color: #e0e0e0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    min-height: 100vh;
+    line-height: 1.6;
+}
+
+.container {
+    background-color: #1e1e1e;
+    padding: 20px 30px;
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.5);
+    width: 100%;
+    max-width: 600px;
+}
+
+header h1 {
+    color: #bb86fc;
+    text-align: center;
+    margin-bottom: 25px;
+    font-size: 1.8em;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label, fieldset legend {
+    display: block;
+    margin-bottom: 8px;
+    color: #c7c7c7;
+    font-weight: bold;
+}
+
+.form-group input[type="text"],
+.form-group input[type="date"],
+.form-group input[type="checkbox"] {
+    background-color: #2c2c2c;
+    color: #e0e0e0;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 10px;
+    width: calc(100% - 22px); /* Account for padding and border */
+    box-sizing: border-box;
+}
+
+.form-group input[type="checkbox"] {
+    width: auto;
+    margin-right: 8px;
+    vertical-align: middle;
+}
+.form-group input[type="checkbox"] + label {
+    display: inline; /* Keep label next to checkbox */
+    font-weight: normal;
+}
+
+
+.form-group input[type="text"]:focus,
+.form-group input[type="date"]:focus {
+    outline: none;
+    border-color: #bb86fc;
+    box-shadow: 0 0 5px rgba(187, 134, 252, 0.3);
+}
+
+fieldset.form-group {
+    border: 1px solid #444;
+    padding: 15px;
+    border-radius: 4px;
+}
+
+fieldset div {
+    margin-bottom: 8px;
+}
+fieldset label {
+    font-weight: normal;
+}
+
+input[type="radio"] {
+    margin-right: 8px;
+    accent-color: #bb86fc; /* Styles the radio button itself */
+}
+
+#customDateFields div {
+    margin-top: 10px;
+}
+#customDateFields label {
+    margin-bottom: 5px;
+}
+
+
+button {
+    background-color: #bb86fc;
+    color: #121212;
+    border: none;
+    padding: 12px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: bold;
+    transition: background-color 0.3s ease;
+    display: block;
+    width: 100%;
+    margin-top: 10px;
+}
+
+button:hover {
+    background-color: #a06cd5;
+}
+
+#resultArea {
+    margin-top: 25px;
+    padding: 15px;
+    background-color: #2c2c2c;
+    border-radius: 4px;
+    border: 1px solid #444;
+}
+
+#resultArea h2 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    color: #bb86fc;
+    font-size: 1.2em;
+}
+
+#generatedLink {
+    color: #87cefa; /* Light Sky Blue for links */
+    text-decoration: none;
+    word-break: break-all;
+}
+
+#generatedLink:hover {
+    text-decoration: underline;
+}
+
+#copyLinkButton {
+    background-color: #03dac6; /* Teal accent for copy button */
+    color: #121212;
+    margin-top: 15px;
+    font-size: 0.9em;
+}
+
+#copyLinkButton:hover {
+    background-color: #01b0a0;
+}
+
+#messageArea {
+    margin-top: 15px;
+    padding: 10px;
+    border-radius: 4px;
+    text-align: center;
+}
+
+.message-success {
+    background-color: #3D9970; /* Greenish */
+    color: #ffffff;
+}
+
+.message-error {
+    background-color: #FF4136; /* Reddish */
+    color: #ffffff;
+}
+
+footer {
+    text-align: center;
+    margin-top: 30px;
+    color: #777;
+    font-size: 0.9em;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    body {
+        padding: 10px;
+    }
+    .container {
+        padding: 15px;
+    }
+    header h1 {
+        font-size: 1.5em;
+    }
+    button {
+        font-size: 0.95em;
+    }
+}


### PR DESCRIPTION
This commit introduces the DJLinkGen project, providing two tools for generating links to the Diário de Justiça Eletrônico:

1.  DJLinkGen-CLI:
    *   Interactive Python CLI tool.
    *   Prompts for OAB number/UF or loads from .env.
    *   Offers date filtering: open, last 5 days, custom range.
    *   Generates the consultation link.
    *   Copies the link to the clipboard.
    *   Opens the link in the default web browser.
    *   Includes `requirements.txt`, `.env.example`, and `README.md`.

2.  DJLinkGen-Web:
    *   Single-page web interface with a dark theme.
    *   Inputs for OAB number/UF with a "Remember me" option (uses localStorage).
    *   Date filtering options similar to CLI.
    *   Generates and displays the link.
    *   Button to copy the link to the clipboard.
    *   Includes `index.html`, `style.css`, `script.js`, `.env.example`, and `README.md`.

Project also includes a global .gitignore and a main README.md linking to the individual tool documentation. All files and features are based on the specifications in `project_espec.md`.